### PR TITLE
Add request router

### DIFF
--- a/configuration_controller/mappings/request_mapping.yml
+++ b/configuration_controller/mappings/request_mapping.yml
@@ -1,0 +1,7 @@
+---
+registrationRequest: registration
+spectrumInquiryRequest: spectrumInquiry
+grantRequest: grant
+heartbeatRequest: heartbeat
+relinquishmentRequest: relinquishment
+deregistrationRequest: deregistration

--- a/configuration_controller/request_router/exceptions.py
+++ b/configuration_controller/request_router/exceptions.py
@@ -1,0 +1,2 @@
+class RequestRouterException(Exception):
+    pass

--- a/configuration_controller/request_router/request_router.py
+++ b/configuration_controller/request_router/request_router.py
@@ -1,0 +1,62 @@
+import json
+import logging
+
+import requests
+import yaml
+from requests import Response
+
+from configuration_controller.request_router.exceptions import RequestRouterException
+
+
+class RequestRouter:
+    """
+    This class is responsible for sending requests to SAS and forwarding SAS responses to Radio Controller.
+    """
+
+    def __init__(self,
+                 sas_url: str,
+                 rc_ingest_url: str,
+                 cert_path: str,
+                 ssl_key_path: str,
+                 request_mapping_file_path: str):
+        self.sas_url = sas_url
+        self.rc_ingest_url = rc_ingest_url
+        self.cert_path = cert_path
+        self.ssl_key_path = ssl_key_path
+        self.post_headers = {'Content-Type': 'application/json'}
+        with open(request_mapping_file_path) as f:
+            self.request_mapping = yaml.load(f, Loader=yaml.SafeLoader)
+
+    def post_to_sas(self, request_json: str) -> Response:
+        """
+        This method parses a JSON request and sends it to the appropriate SAS endpoint.
+        It will only look at the first key of the parsed JSON dict, so if there are multiple request types chunked in
+        one dictionary it will send them to a SAS endpoint pertaining to the first key of the dictionary only.
+        Therefore it is important to pass the requests grouped under one request name
+        :param request_json: JSON object with a name as key and an array of objects as value
+        :return: Response object with SAS response as json payload
+        """
+        request_dict = json.loads(request_json)
+        request_name = next(iter(request_dict))
+        try:
+            sas_method = self.request_mapping[request_name]
+        except KeyError:
+            err_msg = f'Unable to find SAS method matching {request_name}'
+            logging.error(err_msg)
+            raise RequestRouterException(err_msg)
+        sas_response = requests.post(
+            f'{self.sas_url}/{sas_method}',
+            json=request_json,
+            cert=(self.cert_path, self.ssl_key_path),
+            headers=self.post_headers,
+        )
+        return sas_response
+
+    def redirect_sas_response_to_radio_controller(self, response: Response):
+        """
+        The method takes the Response object and passes its payload on to Radio Controller's ingest endpoint
+        :param response: Response object
+        :return: Response object
+        """
+        payload = response.json()
+        return requests.post(self.rc_ingest_url, json=payload, headers=self.post_headers)

--- a/configuration_controller/requirements.txt
+++ b/configuration_controller/requirements.txt
@@ -1,5 +1,10 @@
 APScheduler==3.7.0
+certifi==2020.12.5
 click==7.1.2
+idna==2.10
 pytz==2021.1
+PyYAML==5.4.1
+requests==2.25.1
 six==1.15.0
 tzlocal==2.1
+urllib3==1.26.4

--- a/configuration_controller/tests/requirements.txt
+++ b/configuration_controller/tests/requirements.txt
@@ -1,2 +1,3 @@
 parameterized==0.8.1
 pytest==6.2.3
+requests-mock==1.8.0

--- a/configuration_controller/tests/unit/fixtures/fake_mappings/request_mapping.yml
+++ b/configuration_controller/tests/unit/fixtures/fake_mappings/request_mapping.yml
@@ -1,0 +1,2 @@
+---
+testPostRequest: test_post

--- a/configuration_controller/tests/unit/test_request_routing.py
+++ b/configuration_controller/tests/unit/test_request_routing.py
@@ -1,0 +1,65 @@
+import os
+from unittest import TestCase
+
+import requests_mock
+
+from configuration_controller.request_router.exceptions import RequestRouterException
+from configuration_controller.request_router.request_router import RequestRouter
+
+
+@requests_mock.Mocker()
+class RequestRouterTestCase(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.sas_url = 'https://fake.sas.url'
+        self.rc_ingest_url = 'https://fake.rc.url'
+        self.router = RequestRouter(
+            sas_url=self.sas_url,
+            rc_ingest_url=self.rc_ingest_url,
+            cert_path='fake/cert/path',
+            ssl_key_path='fake/key/path',
+            request_mapping_file_path=self._get_from_fixture("fake_mappings/request_mapping.yml")
+        )
+
+    def test_router_forwarding_existing_sas_methods(self, mocker):
+        # Given
+        self._register_test_post_endpoints(mocker, f'{self.sas_url}/test_post')
+
+        # When
+        resp = self.router.post_to_sas(request_json='{"testPostRequest": [{"foo": "bar"}]}')
+
+        # Then
+        self.assertEqual(200, resp.status_code)
+
+    def test_sas_response_is_forwarded_to_rc(self, mocker):
+        # Given
+        self._register_test_post_endpoints(mocker, f'{self.sas_url}/test_post')
+        self._register_test_post_endpoints(mocker, self.rc_ingest_url)
+
+        # When
+        sas_resp = self.router.post_to_sas(request_json='{"testPostRequest": [{"foo": "bar"}]}')
+        rc_resp = self.router.redirect_sas_response_to_radio_controller(sas_resp)
+
+        # Then
+        self.assertEqual(200, rc_resp.status_code)
+
+    def test_router_raises_exception_for_non_existing_sas_method(self, mocker):
+        # Given
+        self._register_test_post_endpoints(mocker, f'{self.sas_url}/test_post')
+
+        # When / Then
+        with self.assertRaises(RequestRouterException):
+            self.router.post_to_sas(request_json='{"nonExistingSasMethod": [{}]}')
+
+    def _register_test_post_endpoints(self, mocker, url):
+        mocker.register_uri('POST', url, json=self._response_callback)
+
+    @staticmethod
+    def _get_from_fixture(fixture_rel_path):
+        return os.path.join(os.path.dirname(__file__), "fixtures", fixture_rel_path)
+
+    @staticmethod
+    def _response_callback(request, context):
+        context.status_code = 200
+        return request.text


### PR DESCRIPTION
Signed-off-by: Wojciech Sadowy <wojciech.sadowy@freedomfi.com>

[SAS][Client] Add SAS request router


## Summary

SAS request router is responsible for forwarding requests it receives from the consumer to the SAS server and then passing its response back to the Radio Controller.

## Test Plan

Unit tests attached
