### PR TITLE
Simplify request merger

### DIFF
--- a/configuration_controller/request_formatting/exceptions.py
+++ b/configuration_controller/request_formatting/exceptions.py
@@ -1,2 +1,0 @@
-class PayloadFormatException(Exception):
-    pass

--- a/configuration_controller/request_formatting/merger.py
+++ b/configuration_controller/request_formatting/merger.py
@@ -1,34 +1,26 @@
 import json
 from collections import defaultdict
-from json import JSONDecodeError
-
-from configuration_controller.request_formatting.exceptions import PayloadFormatException
+from typing import List
 
 
-def merge_requests(requests_json: str) -> str:
+def merge_requests(requests_list: List[str]) -> str:
     """
-    This function receives an array of JSON objects and merges them into one json object with a subarray of objects as
-    long as the keys of the objects are the same.
-    If the keys differ, it will raise a PayloadFormatException
+    This function receives an array of JSON objects and merges them into one JSON object with request names as keys and
+    sub-arrays of objects as values
 
     example:
 
     '[{"foo": [{...}]}, {"foo": [{...}]}]' will be serialized to '[{"foo": [{...}, {...}]}]'
-    but '[{"foo": [{...}]}, {"baz": [{...}]}]' will raise an exception.
 
-    :param requests_json: JSON serialized array of requests in the following format '[{"foo": [{...}]}, ...]'
+    :param requests_list: List of requests in the following format '[{"foo": [{...}]}, ...]'
     :return: JSON serialized object with a subarray of payloads
     """
-    try:
-        requests = json.loads(requests_json)
-    except JSONDecodeError:
-        raise PayloadFormatException('Requests not in a valid JSON format')
 
     merged_requests = defaultdict(list)
 
-    for request in requests:
-        for request_name, object_list in request.items():
-            if merged_requests and merged_requests.get(request_name) is None:
-                raise PayloadFormatException("Multiple request types detected")
-            merged_requests[request_name].extend(object_list)
+    for request in requests_list:
+        request = json.loads(request)
+        for request_name, payload in request.items():
+            merged_requests[request_name].extend(payload)
+
     return json.dumps(merged_requests)

--- a/configuration_controller/tests/unit/fixtures/fake_request_queues/mixed_queued_requests.py
+++ b/configuration_controller/tests/unit/fixtures/fake_request_queues/mixed_queued_requests.py
@@ -1,5 +1,5 @@
-[
-  {
+queued_requests = [
+  """{
     "registrationRequest": [
       {
         "fccId": "321cba",
@@ -32,8 +32,8 @@
         ]
       }
     ]
-  },
-  {
+  }""",
+  """{
     "spectrumEnquiryRequest": [
       {
         "fccId": "abc123",
@@ -66,5 +66,5 @@
         ]
       }
     ]
-  }
+  }"""
 ]

--- a/configuration_controller/tests/unit/fixtures/fake_request_queues/queued_requests.py
+++ b/configuration_controller/tests/unit/fixtures/fake_request_queues/queued_requests.py
@@ -1,5 +1,5 @@
-[
-  {
+queued_requests = [
+  """{
     "registrationRequest": [
       {
         "fccId": "321cba",
@@ -32,8 +32,8 @@
         ]
       }
     ]
-  },
-  {
+  }""",
+  """{
     "registrationRequest": [
       {
         "fccId": "abc123",
@@ -66,5 +66,5 @@
         ]
       }
     ]
-  }
+  }"""
 ]

--- a/configuration_controller/tests/unit/fixtures/fake_request_queues/queued_requests_with_one_cumulative_request.py
+++ b/configuration_controller/tests/unit/fixtures/fake_request_queues/queued_requests_with_one_cumulative_request.py
@@ -1,5 +1,5 @@
-[
-  {
+queued_requests = [
+  """{
     "registrationRequest": [
       {
         "fccId": "321cba",
@@ -32,8 +32,8 @@
         ]
       }
     ]
-  },
-  {
+  }""",
+  """{
     "registrationRequest": [
       {
         "fccId": "abc123",
@@ -96,5 +96,5 @@
         ]
       }
     ]
-  }
+  }"""
 ]

--- a/configuration_controller/tests/unit/test_request_formatting.py
+++ b/configuration_controller/tests/unit/test_request_formatting.py
@@ -1,55 +1,47 @@
 import json
-import os
 from unittest import TestCase
 
 from parameterized import parameterized
 
-from configuration_controller.request_formatting.merger import PayloadFormatException, merge_requests
+from configuration_controller.request_formatting.merger import merge_requests
+from configuration_controller.tests.unit.fixtures.fake_request_queues.queued_requests import queued_requests
+from configuration_controller.tests.unit.fixtures.fake_request_queues.mixed_queued_requests \
+    import queued_requests as mixed_queued_requests
+from configuration_controller.tests.unit.fixtures.fake_request_queues.queued_requests_with_one_cumulative_request \
+    import queued_requests as queued_requests_with_one_cumulative_request
 
 
 class RequestMergingTestCase(TestCase):
 
-    def test_request_merging_returns_empty_json_obj_for_empty_request(self):
+    def test_request_merging_returns_empty_json_obj_for_empty_request_list(self):
         # Given / When
-        merged_requests = merge_requests('[]')
+        merged_requests = merge_requests([])
 
         # Then
         self.assertEqual('{}', merged_requests)
 
     @parameterized.expand([
-        ('queued_requests.json', 1, 2),
-        ('queued_requests_with_one_cumulative_request.json', 1, 3),
+        (queued_requests, 1, 2),
+        (queued_requests_with_one_cumulative_request, 1, 3),
     ])
-    def test_request_merging_merges_multiple_json_requests_into_one(self, fixture_file, nr_of_keys, nr_of_values):
-        # Given
-        json_requests = self._get_json_from_fixture(fixture_file)
-
-        # When
-        merged_requests = merge_requests(json_requests)
+    def test_request_merging_merges_multiple_requests_into_one(self, _requests, nr_of_keys, nr_of_elems_in_list):
+        # Given / When
+        merged_requests = merge_requests(_requests)
         deserialized_merged_requests = json.loads(merged_requests)
 
         # Then
         self.assertIsInstance(deserialized_merged_requests, dict)
         self.assertEqual(nr_of_keys, len(deserialized_merged_requests.keys()))
         self.assertIsInstance(list(deserialized_merged_requests.values())[0], list)
-        self.assertEqual(nr_of_values, len(list(deserialized_merged_requests.values())[0]))
+        self.assertEqual(nr_of_elems_in_list, len(list(deserialized_merged_requests.values())[0]))
 
-    def test_request_merging_raises_exception_for_mixed_requests_in_one_queue(self):
-        # Given
-        json_requests = self._get_json_from_fixture('mixed_queued_requests.json')
+    def test_request_merging_merges_mixed_type_of_requests_into_one(self):
+        # Given / When
+        merged_requests = merge_requests(mixed_queued_requests)
+        deserialized_merged_requests = json.loads(merged_requests)
 
-        # When / Then
-        with self.assertRaises(PayloadFormatException):
-            merge_requests(json_requests)
-
-    def test_request_merging_raises_exception_for_wrong_request_structure(self):
-        # Given
-
-        # When / Then
-        with self.assertRaises(PayloadFormatException):
-            merge_requests('foo')
-
-    @staticmethod
-    def _get_json_from_fixture(fixture_name):
-        with open(os.path.join(os.path.dirname(__file__), "fixtures/fake_request_queues", fixture_name)) as f:
-            return json.dumps(json.load(f))
+        # Then
+        self.assertEqual(2, len(deserialized_merged_requests.keys()))
+        self.assertEqual(2, len(deserialized_merged_requests.values()))
+        self.assertEqual(1, len(list(deserialized_merged_requests.values())[0]))
+        self.assertEqual(1, len(list(deserialized_merged_requests.values())[1]))


### PR DESCRIPTION
Signed-off-by: Wojciech Sadowy <wojciech.sadowy@freedomfi.com>

[SAS][Client] Simplyfying requests merger

## Summary

Merger does not validate the structure of the requests anymore as
it will be the responsibility of a Prodocol / Radio Controller in future iterations

## Test Plan

Unit tests included
