### PR TITLE
Added horizontal scaling to CC

### DIFF
--- a/configuration_controller/config.py
+++ b/configuration_controller/config.py
@@ -8,6 +8,7 @@ class Config:
     LOG_LEVEL = os.environ.get('LOG_LEVEL', 'DEBUG')
     REQUEST_PROCESSING_INTERVAL = int(os.environ.get('REQUEST_PROCESSING_INTERVAL', 10))
     REQUEST_MAPPING_FILE_PATH = os.environ.get('REQUEST_MAPPING_FILE_PATH', 'mappings/request_mapping.yml')
+    MAX_REQUEST_BATCH_SIZE = int(os.environ.get('MAX_REQUEST_BATCH_SIZE', 100))
 
     # Services
     SAS_URL = os.environ.get('SAS_URL', 'https://fake-sas-service/v1.2')

--- a/configuration_controller/config.py
+++ b/configuration_controller/config.py
@@ -8,7 +8,7 @@ class Config:
     LOG_LEVEL = os.environ.get('LOG_LEVEL', 'DEBUG')
     REQUEST_PROCESSING_INTERVAL = int(os.environ.get('REQUEST_PROCESSING_INTERVAL', 10))
     REQUEST_MAPPING_FILE_PATH = os.environ.get('REQUEST_MAPPING_FILE_PATH', 'mappings/request_mapping.yml')
-    MAX_REQUEST_BATCH_SIZE = int(os.environ.get('MAX_REQUEST_BATCH_SIZE', 100))
+    REQUEST_PROCESSING_LIMIT = int(os.environ.get('REQUEST_PROCESSING_LIMIT', 100))
 
     # Services
     SAS_URL = os.environ.get('SAS_URL', 'https://fake-sas-service/v1.2')

--- a/configuration_controller/request_consumer/request_db_consumer.py
+++ b/configuration_controller/request_consumer/request_db_consumer.py
@@ -1,5 +1,7 @@
 import logging
 
+from sqlalchemy import func
+
 from configuration_controller.custom_types.custom_types import RequestsMap
 from db_service.models import DBRequest, DBRequestState, DBRequestType
 from mappings.types import RequestStates
@@ -10,16 +12,21 @@ logger = logging.getLogger(__name__)
 class RequestDBConsumer:
     """Class to consume requests from the db"""
 
-    def __init__(self, request_type: str):
+    def __init__(self, request_type: str, request_max_batch_size: int):
         self.request_type = request_type
+        self.request_max_batch_size = request_max_batch_size
 
     def get_pending_requests(self, session) -> RequestsMap:
-        db_requests = session.query(DBRequest).join(DBRequestType, DBRequestState).filter(
-            DBRequestType.name == self.request_type,
-            DBRequestState.name == RequestStates.PENDING.value
-        ).all()
+        db_requests = session.query(DBRequest) \
+            .join(DBRequestType, DBRequestState) \
+            .filter(DBRequestType.name == self.request_type,
+                    DBRequestState.name == RequestStates.PENDING.value,
+                    func.pg_try_advisory_xact_lock(DBRequest.id)) \
+            .limit(self.request_max_batch_size)
 
-        if db_requests:
-            logger.info(f"[{self.request_type}] Fetched {len(db_requests)} pending <{self.request_type}> requests.")
+        db_requests_num = db_requests.count()
 
-        return {self.request_type: db_requests}
+        if db_requests_num:
+            logger.info(f"[{self.request_type}] Fetched {db_requests_num} pending <{self.request_type}> requests.")
+
+        return {self.request_type: db_requests.all()}

--- a/configuration_controller/request_consumer/request_db_consumer.py
+++ b/configuration_controller/request_consumer/request_db_consumer.py
@@ -12,21 +12,27 @@ logger = logging.getLogger(__name__)
 class RequestDBConsumer:
     """Class to consume requests from the db"""
 
-    def __init__(self, request_type: str, request_max_batch_size: int):
+    def __init__(self, request_type: str, request_processing_limit: int):
         self.request_type = request_type
-        self.request_max_batch_size = request_max_batch_size
+        self.request_processing_limit = request_processing_limit
 
     def get_pending_requests(self, session) -> RequestsMap:
-        db_requests = session.query(DBRequest) \
+        """
+        Getting requests in pending state and acquiring lock on them if they weren't previously locked
+        by another process. If they have a lock on them, select the ones that don't.
+        """
+        db_requests_query = session.query(DBRequest) \
             .join(DBRequestType, DBRequestState) \
             .filter(DBRequestType.name == self.request_type,
                     DBRequestState.name == RequestStates.PENDING.value,
-                    func.pg_try_advisory_xact_lock(DBRequest.id)) \
-            .limit(self.request_max_batch_size)
+                    func.pg_try_advisory_xact_lock(DBRequest.id))
 
-        db_requests_num = db_requests.count()
+        if self.request_processing_limit > 0:
+            db_requests_query = db_requests_query.limit(self.request_processing_limit)
+
+        db_requests_num = db_requests_query.count()
 
         if db_requests_num:
             logger.info(f"[{self.request_type}] Fetched {db_requests_num} pending <{self.request_type}> requests.")
 
-        return {self.request_type: db_requests.all()}
+        return {self.request_type: db_requests_query.all()}

--- a/configuration_controller/run.py
+++ b/configuration_controller/run.py
@@ -53,7 +53,10 @@ def run():
     for request_type in RequestTypes:
         req_type = request_type.value
         response_type = request_response[req_type]
-        consumer = RequestDBConsumer(request_type=req_type)
+        consumer = RequestDBConsumer(
+            request_type=req_type,
+            request_max_batch_size=config.MAX_REQUEST_BATCH_SIZE,
+        )
         processor = ResponseDBProcessor(
             response_type=response_type,
             request_map_key_func=processor_strategies[req_type]["request_map_key"],

--- a/configuration_controller/tests/unit/test_request_consumer.py
+++ b/configuration_controller/tests/unit/test_request_consumer.py
@@ -1,13 +1,19 @@
+from parameterized import parameterized
+
 from configuration_controller.request_consumer.request_db_consumer import RequestDBConsumer
 from db_service.models import DBRequest, DBRequestState, DBRequestType
+from db_service.session_manager import Session
 from db_service.tests.db_testcase import DBTestCase
+
+
+DEFAULT_MAX_REQUEST_BATCH_SIZE = 10
 
 
 class RegistrationDBConsumerTestCase(DBTestCase):
 
     def test_get_pending_requests_retrieves_empty_list_of_requests_when_no_pending_requests_in_db(self):
         # Given
-        consumer = RequestDBConsumer("someRequest")
+        consumer = RequestDBConsumer("someRequest", request_max_batch_size=DEFAULT_MAX_REQUEST_BATCH_SIZE)
 
         # When
         reqs = consumer.get_pending_requests(self.session)
@@ -17,7 +23,56 @@ class RegistrationDBConsumerTestCase(DBTestCase):
 
     def test_get_pending_requests_retrieves_pending_requests_only(self):
         # Given
-        consumer = RequestDBConsumer("someRequest")
+        consumer = RequestDBConsumer("someRequest", request_max_batch_size=DEFAULT_MAX_REQUEST_BATCH_SIZE)
+
+        self._prepare_two_pending_and_one_processed_request()
+
+        # When
+        reqs = consumer.get_pending_requests(self.session)
+
+        # Then
+        self.assertEqual(2, len(list(reqs.values())[0]))
+
+    @parameterized.expand([
+        (1, 1, 1),
+        (2, 2, 0),
+    ])
+    def test_different_processes_dont_pick_up_each_others_requests(self, max_batch_size, req_count_1, req_count_2):
+        """
+        This is a test for horizontal scaling functionality of the Configuration Controller.
+        It tests if two processes (in this case associated with different Session instances) only pick those requests
+        that have no lock on them.
+        """
+        # Given
+        config = self.get_config()
+        config.MAX_REQUEST_BATCH_SIZE = max_batch_size
+        session1 = Session(bind=self.engine)
+        session2 = Session(bind=self.engine)
+
+        consumer = RequestDBConsumer("someRequest", request_max_batch_size=config.MAX_REQUEST_BATCH_SIZE)
+        self._prepare_two_pending_and_one_processed_request()
+
+        # When
+        reqs1 = consumer.get_pending_requests(session1)
+        reqs2 = consumer.get_pending_requests(session2)
+
+        reqs1_list = list(reqs1.values())[0]
+        reqs2_list = list(reqs2.values())[0]
+
+        session1.commit()
+        session2.commit()
+
+        # Then
+        self.assertEqual(req_count_1, len(reqs1_list))
+        self.assertEqual(req_count_2, len(reqs2_list))
+        if reqs1_list and reqs2_list:
+            # Making sure we're not getting the same requests in both sessions
+            self.assertNotEqual(reqs1_list[0].cbsd_id, reqs2_list[0].cbsd_id)
+
+        session1.close()
+        session2.close()
+
+    def _prepare_two_pending_and_one_processed_request(self):
         req_type = DBRequestType(name="someRequest")
         pending_status = DBRequestState(name="pending")
         processed_status = DBRequestState(name="processed")
@@ -26,9 +81,3 @@ class RegistrationDBConsumerTestCase(DBTestCase):
         req3 = DBRequest(cbsd_id="foo3", type=req_type, state=processed_status, payload={"some": "payload3"})
         self.session.add_all([req1, req2, req3])
         self.session.commit()
-
-        # When
-        reqs = consumer.get_pending_requests(self.session)
-
-        # Then
-        self.assertEqual(2, len(list(reqs.values())[0]))

--- a/tools/deployment/tests/protocol_controller_test_deployment.yml
+++ b/tools/deployment/tests/protocol_controller_test_deployment.yml
@@ -13,7 +13,7 @@ spec:
       - name: protocol-controller-tests
         image: protocol-controller-tests
         command: ["python"]
-        args: ["-m", "pytest", "-vvv", "tests/integration", "--junitxml=/backend/protocol_controller/test-results/test_report.xml"]
+        args: ["-m", "pytest", "-vvv", "-s", "-o", "log_cli=true", "-o", "log_cli_level=DEBUG", "tests/integration", "--junitxml=/backend/protocol_controller/test-results/test_report.xml"]
         env:
         - name: CC_CERT_PATH
           value: "/backend/configuration_controller/certs/device_c.cert"


### PR DESCRIPTION
Signed-off-by: Wojciech Sadowy <wojciech.sadowy@freedomfi.com>

<!--
    "[SAS][Client] Configuration Controller horizontal scaling"
-->

## Summary
Modified the query to fetch pending requests so that once an instance of Configuration Controller picks a batch of N requests, another instance will not pick up the same requests, because a lock had been put on those requests for the duration of the transaction.

## Test Plan

Unit / Integration tests
